### PR TITLE
feat: 重構寵物處理器以使用新的 Gin 引擎和路由註冊

### DIFF
--- a/cmd/petlog/wire.go
+++ b/cmd/petlog/wire.go
@@ -33,7 +33,8 @@ func initPetAPI(c context.Context, cfg config.AppConfig) (http.Handler, func(), 
 
 		// Endpoint & Transport
 		endpoint.MakePetEndpoints,
-		gin.NewPetHandler,
+		gin.NewGinEngine,
+		gin.NewHTTPHandler,
 		wire.Value([]kithttp.ServerOption{}),
 	)
 	return nil, nil, nil

--- a/cmd/petlog/wire_gen.go
+++ b/cmd/petlog/wire_gen.go
@@ -26,6 +26,7 @@ import (
 
 // initPetAPI initializes the pet API.
 func initPetAPI(c context.Context, cfg config.AppConfig) (http.Handler, func(), error) {
+	engine := gin.NewGinEngine()
 	database, cleanup, err := mongodb.NewDatabase(cfg)
 	if err != nil {
 		return nil, nil, err
@@ -38,7 +39,7 @@ func initPetAPI(c context.Context, cfg config.AppConfig) (http.Handler, func(), 
 	listPetsByOwnerHandler := query.NewListPetsByOwnerHandler(petRepository)
 	petEndpoints := endpoint.MakePetEndpoints(createPetHandler, updatePetHandler, deletePetHandler, getPetByIDHandler, listPetsByOwnerHandler)
 	v := _wireValue
-	handler := gin.NewPetHandler(cfg, petEndpoints, v...)
+	handler := gin.NewHTTPHandler(engine, cfg, petEndpoints, v)
 	return handler, func() {
 		cleanup()
 	}, nil

--- a/internal/transport/gin/pet_handler.go
+++ b/internal/transport/gin/pet_handler.go
@@ -12,10 +12,8 @@ import (
 	httptransport "github.com/go-kit/kit/transport/http"
 )
 
-// NewPetHandler returns a new pet handler.
-func NewPetHandler(cfg config.AppConfig, e endpoint.PetEndpoints, options ...httptransport.ServerOption) http.Handler {
-	r := gin.New()
-
+// RegisterPetRoutes registers pet-related routes on the given Gin engine.
+func RegisterPetRoutes(r *gin.Engine, cfg config.AppConfig, e endpoint.PetEndpoints, options ...httptransport.ServerOption) {
 	// Error handler
 	opts := []httptransport.ServerOption{
 		httptransport.ServerErrorHandler(transport.NewLogErrorHandler(nil)), // replace nil with a logger
@@ -26,7 +24,8 @@ func NewPetHandler(cfg config.AppConfig, e endpoint.PetEndpoints, options ...htt
 	// Public endpoints
 
 	// Private endpoints
-	petRoutes := r.Group("/api/v1/pets")
+	v1 := r.Group("/api/v1")
+	petRoutes := v1.Group("/pets")
 	petRoutes.Use(EnsureValidToken(cfg))
 	{
 		petRoutes.POST("", CreatePet(e, opts...))
@@ -35,8 +34,6 @@ func NewPetHandler(cfg config.AppConfig, e endpoint.PetEndpoints, options ...htt
 		petRoutes.DELETE("/:id", DeletePet(e, opts...))
 		petRoutes.GET("", ListPets(e, opts...))
 	}
-
-	return r
 }
 
 // CreatePet godoc

--- a/internal/transport/gin/router.go
+++ b/internal/transport/gin/router.go
@@ -1,0 +1,32 @@
+package gin
+
+import (
+	"net/http"
+
+	"github.com/blackhorseya/petlog/internal/config"
+	"github.com/blackhorseya/petlog/internal/endpoint"
+	"github.com/gin-gonic/gin"
+	httptransport "github.com/go-kit/kit/transport/http"
+)
+
+// NewGinEngine creates a new Gin engine with default middleware.
+func NewGinEngine() *gin.Engine {
+	return gin.Default()
+}
+
+// NewHTTPHandler sets up the routing and returns the main HTTP handler.
+// It acts as an aggregator for all route registration functions.
+func NewHTTPHandler(
+	r *gin.Engine,
+	cfg config.AppConfig,
+	petEndpoints endpoint.PetEndpoints,
+	options []httptransport.ServerOption,
+) http.Handler {
+	// Register routes for the "pet" module.
+	RegisterPetRoutes(r, cfg, petEndpoints, options...)
+
+	// In the future, other modules can be registered here:
+	// RegisterHealthLogRoutes(r, cfg, healthLogEndpoints, options...)
+
+	return r
+}


### PR DESCRIPTION
### **User description**
## Context:

重構寵物處理器以整合新的 Gin 引擎，提升路由註冊的靈活性和可維護性。

## Major Changes:

- 引入新的 Gin 引擎以取代舊的處理器。

- 更新路由註冊方式，將寵物相關路由註冊到新的引擎上。

- 整合 HTTP 處理器以便未來擴展其他模組的路由註冊。


___

### **PR Type**
Enhancement


___

### **Description**
- Add Gin engine and HTTP handler setup

- Replace NewPetHandler with RegisterPetRoutes

- Update DI to use NewGinEngine/NewHTTPHandler

- Create router.go with routing aggregator


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>wire.go</strong><dd><code>Use NewGinEngine and NewHTTPHandler in DI</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

cmd/petlog/wire.go

<li>Removed <code>gin.NewPetHandler</code> from injector<br> <li> Added <code>gin.NewGinEngine</code> provider<br> <li> Added <code>gin.NewHTTPHandler</code> call<br> <li> Updated wire dependencies sequence


</details>


  </td>
  <td><a href="https://github.com/blackhorseya/petlog/pull/8/files#diff-f214078d5ee4902ce2a303c3fcc516032e873e6e857f5ccce67cf3c8f271ec40">+2/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>wire_gen.go</strong><dd><code>Initialize Gin engine in generated wire code</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

cmd/petlog/wire_gen.go

<li>Initialized <code>engine := gin.NewGinEngine()</code><br> <li> Replaced <code>gin.NewPetHandler</code> with <code>NewHTTPHandler</code><br> <li> Passed engine to HTTP handler<br> <li> Adjusted return signature to include error


</details>


  </td>
  <td><a href="https://github.com/blackhorseya/petlog/pull/8/files#diff-41dafa6f97c7b76da690c2509944962e0a3d54f1bec04bd4c6bfa52e2ac1a18b">+2/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>pet_handler.go</strong><dd><code>Extract pet routes into RegisterPetRoutes</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

internal/transport/gin/pet_handler.go

<li>Removed <code>NewPetHandler</code> function<br> <li> Introduced <code>RegisterPetRoutes</code> for pet routes<br> <li> Changed route grouping to use <code>/api/v1</code><br> <li> Dropped direct handler return


</details>


  </td>
  <td><a href="https://github.com/blackhorseya/petlog/pull/8/files#diff-ee36ce6b57719580c10c0760b6175585cbdedd3f7ba40942820ba767fad0a0c8">+4/-7</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>router.go</strong><dd><code>Add Gin router and HTTP handler aggregator</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

internal/transport/gin/router.go

<li>Added <code>NewGinEngine</code> to create Gin default engine<br> <li> Added <code>NewHTTPHandler</code> to setup all routes<br> <li> Calls <code>RegisterPetRoutes</code> internally<br> <li> Placeholder for future module registrations


</details>


  </td>
  <td><a href="https://github.com/blackhorseya/petlog/pull/8/files#diff-6a7abb3160a07ed221aa8cdee60cd70fb0045f0aa5d4334c02bd115b5f1bd5b0">+32/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>