### PR TITLE
fix: medical records link position

### DIFF
--- a/web/src/components/layout/header.tsx
+++ b/web/src/components/layout/header.tsx
@@ -66,7 +66,7 @@ export function Header({ onMenuToggle, isMenuOpen }: HeaderProps) {
             健康記錄
           </Link>
           <Link
-            href="/medical"
+            href="/medical-records"
             className="transition-colors hover:text-foreground/80 text-foreground/60"
           >
             醫療記錄

--- a/web/src/components/navigation/mobile-nav.tsx
+++ b/web/src/components/navigation/mobile-nav.tsx
@@ -36,7 +36,7 @@ const mobileNavigation = [
   },
   {
     name: "醫療",
-    href: "/medical",
+    href: "/medical-records",
     icon: FileText,
   },
 ]

--- a/web/src/components/navigation/mobile-sidebar.tsx
+++ b/web/src/components/navigation/mobile-sidebar.tsx
@@ -44,7 +44,7 @@ const navigation = [
   },
   {
     name: "醫療記錄",
-    href: "/medical",
+    href: "/medical-records",
     icon: FileText,
   },
   {


### PR DESCRIPTION
Correct medical record navigation links to point to the correct `/medical-records` path.